### PR TITLE
fixed error with HasBody contact not implemented by using HasJsonBody trait

### DIFF
--- a/src/Requests/DripCampaigns/AddToDoNotEmailListRequest.php
+++ b/src/Requests/DripCampaigns/AddToDoNotEmailListRequest.php
@@ -4,9 +4,10 @@ namespace HelgeSverre\Snov\Requests\DripCampaigns;
 
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
+use Saloon\Contracts\Body\HasBody;
 use Saloon\Traits\Body\HasJsonBody;
 
-class AddToDoNotEmailListRequest extends Request
+class AddToDoNotEmailListRequest extends Request implements HasBody
 {
     use HasJsonBody;
 

--- a/src/Requests/DripCampaigns/ChangeRecipientsStatusRequest.php
+++ b/src/Requests/DripCampaigns/ChangeRecipientsStatusRequest.php
@@ -4,9 +4,10 @@ namespace HelgeSverre\Snov\Requests\DripCampaigns;
 
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
+use Saloon\Contracts\Body\HasBody;
 use Saloon\Traits\Body\HasJsonBody;
 
-class ChangeRecipientsStatusRequest extends Request
+class ChangeRecipientsStatusRequest extends Request implements HasBody
 {
     use HasJsonBody;
 

--- a/src/Requests/EmailFinder/AddNamesToFindEmailsRequest.php
+++ b/src/Requests/EmailFinder/AddNamesToFindEmailsRequest.php
@@ -4,9 +4,10 @@ namespace HelgeSverre\Snov\Requests\EmailFinder;
 
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
+use Saloon\Contracts\Body\HasBody;
 use Saloon\Traits\Body\HasJsonBody;
 
-class AddNamesToFindEmailsRequest extends Request
+class AddNamesToFindEmailsRequest extends Request implements HasBody
 {
     use HasJsonBody;
 

--- a/src/Requests/EmailFinder/AddURLToSearchForProspectRequest.php
+++ b/src/Requests/EmailFinder/AddURLToSearchForProspectRequest.php
@@ -4,9 +4,10 @@ namespace HelgeSverre\Snov\Requests\EmailFinder;
 
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
+use Saloon\Contracts\Body\HasBody;
 use Saloon\Traits\Body\HasJsonBody;
 
-class AddURLToSearchForProspectRequest extends Request
+class AddURLToSearchForProspectRequest extends Request implements HasBody
 {
     use HasJsonBody;
 

--- a/src/Requests/EmailFinder/EmailCountRequest.php
+++ b/src/Requests/EmailFinder/EmailCountRequest.php
@@ -4,9 +4,10 @@ namespace HelgeSverre\Snov\Requests\EmailFinder;
 
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
+use Saloon\Contracts\Body\HasBody;
 use Saloon\Traits\Body\HasJsonBody;
 
-class EmailCountRequest extends Request
+class EmailCountRequest extends Request implements HasBody
 {
     use HasJsonBody;
 

--- a/src/Requests/EmailFinder/EmailFinderRequest.php
+++ b/src/Requests/EmailFinder/EmailFinderRequest.php
@@ -4,9 +4,10 @@ namespace HelgeSverre\Snov\Requests\EmailFinder;
 
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
+use Saloon\Contracts\Body\HasBody;
 use Saloon\Traits\Body\HasJsonBody;
 
-class EmailFinderRequest extends Request
+class EmailFinderRequest extends Request implements HasBody
 {
     use HasJsonBody;
 

--- a/src/Requests/EmailFinder/GetProfileWithEmailRequest.php
+++ b/src/Requests/EmailFinder/GetProfileWithEmailRequest.php
@@ -4,9 +4,10 @@ namespace HelgeSverre\Snov\Requests\EmailFinder;
 
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
+use Saloon\Contracts\Body\HasBody;
 use Saloon\Traits\Body\HasJsonBody;
 
-class GetProfileWithEmailRequest extends Request
+class GetProfileWithEmailRequest extends Request implements HasBody
 {
     use HasJsonBody;
 

--- a/src/Requests/EmailFinder/GetProspectWithURLRequest.php
+++ b/src/Requests/EmailFinder/GetProspectWithURLRequest.php
@@ -4,9 +4,10 @@ namespace HelgeSverre\Snov\Requests\EmailFinder;
 
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
+use Saloon\Contracts\Body\HasBody;
 use Saloon\Traits\Body\HasJsonBody;
 
-class GetProspectWithURLRequest extends Request
+class GetProspectWithURLRequest extends Request implements HasBody
 {
     use HasJsonBody;
 

--- a/src/Requests/EmailVerifier/AddEmailsForVerificationRequest.php
+++ b/src/Requests/EmailVerifier/AddEmailsForVerificationRequest.php
@@ -4,9 +4,10 @@ namespace HelgeSverre\Snov\Requests\EmailVerifier;
 
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
+use Saloon\Contracts\Body\HasBody;
 use Saloon\Traits\Body\HasJsonBody;
 
-class AddEmailsForVerificationRequest extends Request
+class AddEmailsForVerificationRequest extends Request implements HasBody
 {
     use HasJsonBody;
 

--- a/src/Requests/EmailVerifier/EmailVerifierRequest.php
+++ b/src/Requests/EmailVerifier/EmailVerifierRequest.php
@@ -4,9 +4,10 @@ namespace HelgeSverre\Snov\Requests\EmailVerifier;
 
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
+use Saloon\Contracts\Body\HasBody;
 use Saloon\Traits\Body\HasJsonBody;
 
-class EmailVerifierRequest extends Request
+class EmailVerifierRequest extends Request implements HasBody
 {
     use HasJsonBody;
 

--- a/src/Requests/ProspectManagement/AddProspectToListRequest.php
+++ b/src/Requests/ProspectManagement/AddProspectToListRequest.php
@@ -4,9 +4,10 @@ namespace HelgeSverre\Snov\Requests\ProspectManagement;
 
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
+use Saloon\Contracts\Body\HasBody;
 use Saloon\Traits\Body\HasJsonBody;
 
-class AddProspectToListRequest extends Request
+class AddProspectToListRequest extends Request implements HasBody
 {
     use HasJsonBody;
 

--- a/src/Requests/ProspectManagement/CreateNewProspectListRequest.php
+++ b/src/Requests/ProspectManagement/CreateNewProspectListRequest.php
@@ -4,9 +4,10 @@ namespace HelgeSverre\Snov\Requests\ProspectManagement;
 
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
+use Saloon\Contracts\Body\HasBody;
 use Saloon\Traits\Body\HasJsonBody;
 
-class CreateNewProspectListRequest extends Request
+class CreateNewProspectListRequest extends Request implements HasBody
 {
     use HasJsonBody;
 

--- a/src/Requests/ProspectManagement/FindProspectByEmailRequest.php
+++ b/src/Requests/ProspectManagement/FindProspectByEmailRequest.php
@@ -4,9 +4,10 @@ namespace HelgeSverre\Snov\Requests\ProspectManagement;
 
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
+use Saloon\Contracts\Body\HasBody;
 use Saloon\Traits\Body\HasJsonBody;
 
-class FindProspectByEmailRequest extends Request
+class FindProspectByEmailRequest extends Request implements HasBody
 {
     use HasJsonBody;
 

--- a/src/Requests/ProspectManagement/FindProspectByIDRequest.php
+++ b/src/Requests/ProspectManagement/FindProspectByIDRequest.php
@@ -4,9 +4,10 @@ namespace HelgeSverre\Snov\Requests\ProspectManagement;
 
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
+use Saloon\Contracts\Body\HasBody;
 use Saloon\Traits\Body\HasJsonBody;
 
-class FindProspectByIDRequest extends Request
+class FindProspectByIDRequest extends Request implements HasBody
 {
     use HasJsonBody;
 

--- a/src/Requests/ProspectManagement/ViewProspectsInListRequest.php
+++ b/src/Requests/ProspectManagement/ViewProspectsInListRequest.php
@@ -4,9 +4,10 @@ namespace HelgeSverre\Snov\Requests\ProspectManagement;
 
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
+use Saloon\Contracts\Body\HasBody;
 use Saloon\Traits\Body\HasJsonBody;
 
-class ViewProspectsInListRequest extends Request
+class ViewProspectsInListRequest extends Request implements HasBody
 {
     use HasJsonBody;
 

--- a/src/Requests/Webhooks/AddWebhookRequest.php
+++ b/src/Requests/Webhooks/AddWebhookRequest.php
@@ -4,9 +4,10 @@ namespace HelgeSverre\Snov\Requests\Webhooks;
 
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
+use Saloon\Contracts\Body\HasBody;
 use Saloon\Traits\Body\HasJsonBody;
 
-class AddWebhookRequest extends Request
+class AddWebhookRequest extends Request implements HasBody
 {
     use HasJsonBody;
 

--- a/src/Requests/Webhooks/ChangeWebhookStatusRequest.php
+++ b/src/Requests/Webhooks/ChangeWebhookStatusRequest.php
@@ -4,9 +4,10 @@ namespace HelgeSverre\Snov\Requests\Webhooks;
 
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
+use Saloon\Contracts\Body\HasBody;
 use Saloon\Traits\Body\HasJsonBody;
 
-class ChangeWebhookStatusRequest extends Request
+class ChangeWebhookStatusRequest extends Request implements HasBody
 {
     use HasJsonBody;
 

--- a/src/Requests/Webhooks/DeleteAWebhookRequest.php
+++ b/src/Requests/Webhooks/DeleteAWebhookRequest.php
@@ -4,9 +4,10 @@ namespace HelgeSverre\Snov\Requests\Webhooks;
 
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
+use Saloon\Contracts\Body\HasBody;
 use Saloon\Traits\Body\HasJsonBody;
 
-class DeleteAWebhookRequest extends Request
+class DeleteAWebhookRequest extends Request implements HasBody
 {
     use HasJsonBody;
 


### PR DESCRIPTION
Fixed exception:

> You have added a body trait without implementing `Saloon\Contracts\Body\HasBody` on your request or connector.

Based on the [documentation](https://docs.saloon.dev/the-basics/request-body-data/json-body)
when using HasJsonBody in Request, you need to implement _Saloon\Contracts\Body\HasBody_ contract

https://github.com/saloonphp/saloon/blob/d5bb5d6d72ed33efe19a8463ef259f0aa7e98579/src/Traits/Body/ChecksForHasBody.php#L24